### PR TITLE
Improve HOC composability

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,7 @@ npm install --save react-trycatch
 ## Usage
 
 ### 1. Default Usage
+
 ```jsx
 import React from 'react';
 import TryCatch from 'react-trycatch';
@@ -29,10 +30,11 @@ class MyComponent extends React.Component {
     }
 }
 
-export default TryCatch(MyComponent);
+export default TryCatch()(MyComponent);
 ```
 
 ### 2. With Options
+
 ```jsx
 import React from 'react';
 import TryCatch from 'react-trycatch';
@@ -47,10 +49,10 @@ class MyComponent extends React.Component {
     }
 }
 
-export default TryCatch(MyComponent, {
+export default TryCatch({
     replacement: (<div>Replacement on error</div>),
     onError: (error, info) => {
         // catch
     }
-});
+})(MyComponent);
 ```

--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -10,4 +10,4 @@ class App extends React.Component {
     }
 }
 
-export default TryCatch(App);
+export default TryCatch()(App);

--- a/src/components/withErrorBoundary.js
+++ b/src/components/withErrorBoundary.js
@@ -1,18 +1,20 @@
 import React from 'react';
 import ErrorBoundary from './ErrorBoundary';
 
-export default (WrappedComponent, options = {}) => {
-    return class withErrorBoundary extends React.Component {
-        render() {
-            const { replacement, onError } = options;
-            return (
-                <ErrorBoundary
-                    replacement={replacement}
-                    onError={onError}
-                >
-                    <WrappedComponent {...this.props} />
-                </ErrorBoundary>
-            );
+export default (options = {}) => {
+    return WrappedComponent => {
+        return class withErrorBoundary extends React.Component {
+            render() {
+                const { replacement, onError } = options;
+                return (
+                    <ErrorBoundary
+                        replacement={replacement}
+                        onError={onError}
+                    >
+                        <WrappedComponent {...this.props} />
+                    </ErrorBoundary>
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
This PR updates the `withErrorBoundary` higher order component to make it composable with other HOCs.

See [this](https://reactjs.org/docs/higher-order-components.html#convention-maximizing-composability) for more details on composability of HOCs.